### PR TITLE
Update unittests_substitution.c for 

### DIFF
--- a/programming-assignments/PA1/tests/unittests_substitution.c
+++ b/programming-assignments/PA1/tests/unittests_substitution.c
@@ -67,9 +67,10 @@ Test(SubstitutionCipher, decryption_key, .disabled=false) {
   }
   decryption_key = get_decryption_key(encryption_key);
   cr_assert_not_null(decryption_key);
-
+  
+  // Test if the decryption key works along with the encryption key.
   for (int i = 0; i < 26; i++) {
-    cr_assert_eq(expected_decryption_key[i], decryption_key[i]);
+    cr_assert_eq(encryption_key[decryption_key[i]],expected_decryption_key[i]);
   }
 }
 


### PR DESCRIPTION
This test is a somewhat improved way of testing the functionality of `get_decryption_key()`. It expects the actual decryption key in return. 